### PR TITLE
Chore: Update pre-commit deps to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   ##########
 
   - repo: https://github.com/ambv/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -29,13 +29,13 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: ["--max-line-length=120"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.11.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -45,6 +45,6 @@ repos:
           - types-PyYAML
 
   - repo: https://github.com/rhysd/actionlint
-    rev: ea8102762106cdca9c88829f1295b39a544706f3  # frozen: v1.6.26
+    rev: v1.7.1
     hooks:
       - id: actionlint


### PR DESCRIPTION
black 24.4.2 -> 24.8.0
flake8 7.0.0 -> 7.1.1
mypy v1.10.0 -> v1.11.1
actionlint v1.6.26 -> v1.7.1